### PR TITLE
Changed explicit User relation to configurable setting

### DIFF
--- a/security/models.py
+++ b/security/models.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2011, SD Elements. See LICENSE.txt for details.
 
-from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
+from django.conf import settings
 
 
 class PasswordExpiry(models.Model):
@@ -15,7 +15,7 @@ class PasswordExpiry(models.Model):
     """
 
     # Not one-to-one because some users may never receive an expiry date.
-    user = models.ForeignKey(User, unique=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, unique=True)
 
     password_expiry_date = models.DateTimeField(
         auto_now_add=True,

--- a/security/models.py
+++ b/security/models.py
@@ -1,8 +1,15 @@
 # Copyright (c) 2011, SD Elements. See LICENSE.txt for details.
 
+from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
 from django.conf import settings
+
+
+# Finding proper User model that we can set Foreign key to.
+# In newer versions of Django default user model can be specified in settings
+# as `AUTH_USER_MODEL`
+USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', User)
 
 
 class PasswordExpiry(models.Model):
@@ -15,7 +22,7 @@ class PasswordExpiry(models.Model):
     """
 
     # Not one-to-one because some users may never receive an expiry date.
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, unique=True)
+    user = models.ForeignKey(USER_MODEL, unique=True)
 
     password_expiry_date = models.DateTimeField(
         auto_now_add=True,


### PR DESCRIPTION
because hardcoding User in a ForeignKey stops people from specifing
alternative user models using settings.AUTH_USER_MODEL

This fix silences `fields.E301` error raised by Django system check (https://docs.djangoproject.com/en/1.8/ref/checks/#related-fields) for users that, for example, use django-authtools or declare own user models based on `django.contrib.auth.models.AbstractUser`.

Thanks and best regards :),
Marek