### PR TITLE
Fix paramter passing in logging messages

### DIFF
--- a/security/auth_throttling/views.py
+++ b/security/auth_throttling/views.py
@@ -20,11 +20,11 @@ def reset_username_throttle(request, user_id=None, redirect_url="/"):
     try:
         username = User.objects.get(id=user_id).username
     except User.DoesNotExist:
-        logger.error("Couldn't find username for user id %s." % user_id)
+        logger.error("Couldn't find username for user id %s.", user_id)
         raise Http404()
 
     reset_counters(username=username)
-    logger.info("Authentication throttling reset for user id %s." % user_id)
+    logger.info("Authentication throttling reset for user id %s.", user_id)
 
     # TODO: Sanitize redirect_url, even though it's coming from an admin?
     return HttpResponseRedirect(redirect_url)

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -571,10 +571,7 @@ class ContentSecurityPolicyMiddleware(object):
 
     def _csp_loc_builder(self, key, value):
         if not isinstance(value, (list, tuple)):
-            logger.warn(
-                'Arguments to {0} must be given as list or tuple'
-                .format(key),
-            )
+            logger.warn('Arguments to %s must be given as list or tuple', key)
             raise django.core.exceptions.MiddlewareNotUsed
 
         csp_loc_string = "{0}".format(key)
@@ -591,10 +588,7 @@ class ContentSecurityPolicyMiddleware(object):
 
     def _csp_sandbox_builder(self, key, value):
         if not isinstance(value, (list, tuple)):
-            logger.warn(
-                'Arguments to {0} must be given as list or tuple'
-                .format(key),
-            )
+            logger.warn('Arguments to %s must be given as list or tuple', key)
             raise django.core.exceptions.MiddlewareNotUsed
 
         csp_sandbox_string = "{0}".format(key)
@@ -602,9 +596,7 @@ class ContentSecurityPolicyMiddleware(object):
             if opt in self._CSP_SANDBOX_ARGS:
                 csp_sandbox_string += " {0}".format(opt)
             else:
-                logger.warn(
-                    'Invalid CSP sandbox argument {0}'.format(opt),
-                )
+                logger.warn('Invalid CSP sandbox argument %s', opt)
                 raise django.core.exceptions.MiddlewareNotUsed
 
         return csp_sandbox_string
@@ -615,14 +607,14 @@ class ContentSecurityPolicyMiddleware(object):
 
     def _csp_referrer_builder(self, key, value):
         if value not in self._CSP_REF_ARGS:
-            logger.warning('Invalid CSP {0} value {1}'.format(key, value))
+            logger.warning('Invalid CSP %s value %s', key, value)
             raise django.core.exceptions.MiddlewareNotUsed
 
         return "{0} {1}".format(key, value)
 
     def _csp_reflected_xss_builder(self, key, value):
         if value not in self._CSP_XSS_ARGS:
-            logger.warning('Invalid CSP {0} value {1}'.format(key, value))
+            logger.warning('Invalid CSP %s value %s', key, value)
             raise django.core.exceptions.MiddlewareNotUsed
 
         return "{0} {1}".format(key, value)
@@ -650,7 +642,7 @@ class ContentSecurityPolicyMiddleware(object):
                 )
 
             else:
-                logger.warning('Invalid CSP type {0}'.format(key))
+                logger.warning('Invalid CSP type %s', key)
                 raise django.core.exceptions.MiddlewareNotUsed
 
         return '; '.join(csp_components)
@@ -668,17 +660,17 @@ class ContentSecurityPolicyMiddleware(object):
             self._enforce = False
         else:
             logger.warn(
-                'Invalid CSP_MODE {0}, "enforce" or "report-only" allowed'
-                .format(csp_mode),
+                'Invalid CSP_MODE %s, "enforce" or "report-only" allowed',
+                csp_mode
             )
             raise django.core.exceptions.MiddlewareNotUsed
 
         if not (csp_dict or csp_string):
-            logger.warning('{0}, none found'.format(err_msg))
+            logger.warning('%s, none found', err_msg)
             raise django.core.exceptions.MiddlewareNotUsed
 
         if csp_dict and csp_string:
-            logger.warning('{0}, not both'.format(err_msg))
+            logger.warning('%s, not both', err_msg)
             raise django.core.exceptions.MiddlewareNotUsed
 
         # build or copy CSP as string
@@ -821,15 +813,15 @@ class SessionExpiryPolicyMiddleware(BaseMiddleware):
     def load_setting(self, setting, value):
         if setting == 'SESSION_COOKIE_AGE':
             self.SESSION_COOKIE_AGE = value or self.SECONDS_PER_DAY
-            logger.debug("Max Session Cookie Age is %d seconds" % (
-                self.SESSION_COOKIE_AGE,
-            ))
+            logger.debug("Max Session Cookie Age is %d seconds",
+                         self.SESSION_COOKIE_AGE
+                         )
         elif setting == 'SESSION_INACTIVITY_TIMEOUT':
             # half an hour in seconds
             self.SESSION_INACTIVITY_TIMEOUT = value or self.SECONDS_PER_30MINS
-            logger.debug("Session Inactivity Timeout is %d seconds" % (
-                self.SESSION_INACTIVITY_TIMEOUT,
-            ))
+            logger.debug("Session Inactivity Timeout is %d seconds",
+                         self.SESSION_INACTIVITY_TIMEOUT
+                         )
 
     def process_request(self, request):
         """
@@ -851,7 +843,7 @@ class SessionExpiryPolicyMiddleware(BaseMiddleware):
     def process_new_session(self, request):
         now = timezone.now()
         session = request.session
-        logger.debug("New session %s started: %s" % (session.session_key, now))
+        logger.debug("New session %s started: %s", session.session_key, now)
         session[self.START_TIME_KEY] = now
         session[self.LAST_ACTIVITY_KEY] = now
 
@@ -861,14 +853,14 @@ class SessionExpiryPolicyMiddleware(BaseMiddleware):
         start_time = session[self.START_TIME_KEY]
         last_activity_time = session[self.LAST_ACTIVITY_KEY]
 
-        logger.debug("Session %s started: %s" % (
-            session.session_key,
-            start_time,
-        ))
-        logger.debug("Session %s last active: %s" % (
-            session.session_key,
-            last_activity_time,
-        ))
+        logger.debug("Session %s started: %s",
+                     session.session_key,
+                     start_time
+                     )
+        logger.debug("Session %s last active: %s",
+                     session.session_key,
+                     last_activity_time
+                     )
 
         session_age = self.get_diff_in_seconds(now, start_time)
         session_too_old = session_age > self.SESSION_COOKIE_AGE
@@ -877,11 +869,11 @@ class SessionExpiryPolicyMiddleware(BaseMiddleware):
         session_inactive = session_lastactive > self.SESSION_INACTIVITY_TIMEOUT
 
         if session_too_old or session_inactive:
-            logger.debug("Session %s is inactive." % (session.session_key,))
+            logger.debug("Session %s is inactive.", session.session_key)
             logout(request)
             return
 
-        logger.debug("Session %s is still active." % (session.session_key,))
+        logger.debug("Session %s is still active.", session.session_key)
         session[self.LAST_ACTIVITY_KEY] = now
 
     def get_diff_in_seconds(self, now, time):

--- a/security/views.py
+++ b/security/views.py
@@ -55,24 +55,24 @@ def csp_report(request, csp_save=False, csp_log=True):
 
     # http://www.w3.org/TR/CSP/#sample-violation-report
     if not request.method == 'POST':
-        log.debug('Unexpect CSP report method {0}'.format(request.method))
+        log.debug('Unexpect CSP report method %s', request.method)
         return HttpResponseForbidden()
 
     if (
         'CONTENT_TYPE' not in request.META
         or request.META['CONTENT_TYPE'] != 'application/json'
     ):
-        log.debug('Missing CSP report Content-Type {0}'.format(request.META))
+        log.debug('Missing CSP report Content-Type %s', request.META)
         return HttpResponseForbidden()
 
     try:
         csp_dict = json.loads(request.body)
     except ValueError:
-        log.debug('Cannot JSON decode CSP report {0}'.format(request.body))
+        log.debug('Cannot JSON decode CSP report %s', request.body)
         return HttpResponseForbidden()
 
     if 'csp-report' not in csp_dict:
-        log.debug('Invalid CSP report structure {0}'.format(csp_dict))
+        log.debug('Invalid CSP report structure %s', csp_dict)
         return HttpResponseForbidden()
 
     report = csp_dict['csp-report']
@@ -83,9 +83,8 @@ def csp_report(request, csp_save=False, csp_log=True):
     if csp_log:
         log.warn(
             'Content Security Policy violation: '
-            '{0}, reporting IP {1}, user agent {2}'.format(
-                report, reporting_ip, reporting_ua,
-            ),
+            '%s, reporting IP %s, user agent %s',
+            report, reporting_ip, reporting_ua
         )
 
     # save received CSP violation to database


### PR DESCRIPTION
Pass parameters into logger calls directly instead of pre-merging
with the logger message. This way the logs are easier to maintain
and process. The code is also faster when logging is turned off
since it doesn't have to evaluate all params and render them into
strings.

This is in compliance with Python logging best practices.