### PR TITLE
Add support for both report-only and content-security CSP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # python compiled files
 *.pyc
 *.pyo
+*.egg-info
 
 # back up files from VIM / Emacs
 *~

--- a/security/auth.py
+++ b/security/auth.py
@@ -17,9 +17,9 @@ def min_length(n):
             raise ValidationError(message)
     return validate
 
+
 # The error messages from the RegexValidators don't display properly unless we
 # explicitly supply an empty error code.
-
 lowercase = RegexValidator(
     r"[a-z]",
     _("It must contain at least one lowercase letter."),

--- a/security/views.py
+++ b/security/views.py
@@ -57,10 +57,8 @@ def csp_report(request, csp_save=False, csp_log=True):
         log.debug('Unexpect CSP report method %s', request.method)
         return HttpResponseForbidden()
 
-    if (
-        'CONTENT_TYPE' not in request.META or
-        request.META['CONTENT_TYPE'] != 'application/json'
-    ):
+    content_type = request.META.get('CONTENT_TYPE', None)
+    if content_type != 'application/json':
         log.debug('Missing CSP report Content-Type %s', request.META)
         return HttpResponseForbidden()
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(name="django-security",
       install_requires=[
           'django>=1.11',
           'ua_parser>=0.7.1',
-          'python-dateutil==2.8.0',
+          'python-dateutil==2.8.1',
       ],
       cmdclass={'test': Test})

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -972,19 +972,19 @@ class ContentSecurityPolicyTests(TestCase):
 
     def test_enforced_by_default(self):
         with self.settings(CSP_MODE=None):
-            response = self.client.get('/accounts/login/')
+            response = self.client.get(settings.LOGIN_URL)
             self.assertIn('Content-Security-Policy', response)
             self.assertNotIn('Content-Security-Policy-Report-Only', response)
 
     def test_enforced_when_on(self):
         with self.settings(CSP_MODE='enforce'):
-            response = self.client.get('/accounts/login/')
+            response = self.client.get(settings.LOGIN_URL)
             self.assertIn('Content-Security-Policy', response)
             self.assertNotIn('Content-Security-Policy-Report-Only', response)
 
     def test_report_only_set(self):
         with self.settings(CSP_MODE='report-only'):
-            response = self.client.get('/accounts/login/')
+            response = self.client.get(settings.LOGIN_URL)
             self.assertNotIn('Content-Security-Policy', response)
             self.assertIn('Content-Security-Policy-Report-Only', response)
 

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -990,7 +990,7 @@ class ContentSecurityPolicyTests(TestCase):
 
     def test_both_enforce_and_report_only(self):
         with self.settings(CSP_MODE='enforce-and-report-only'):
-            response = self.client.get('/accounts/login/')
+            response = self.client.get(settings.LOGIN_URL)
             self.assertIn('Content-Security-Policy', response)
             self.assertIn('Content-Security-Policy-Report-Only', response)
 

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -988,6 +988,12 @@ class ContentSecurityPolicyTests(TestCase):
             self.assertNotIn('Content-Security-Policy', response)
             self.assertIn('Content-Security-Policy-Report-Only', response)
 
+    def test_both_enforce_and_report_only(self):
+        with self.settings(CSP_MODE='enforce-and-report-only'):
+            response = self.client.get('/accounts/login/')
+            self.assertIn('Content-Security-Policy', response)
+            self.assertIn('Content-Security-Policy-Report-Only', response)
+
     def test_invalid_csp_mode(self):
         with self.settings(CSP_MODE='invalid'):
             self.assertRaises(

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,13 @@ commands_post = coverage report
 basepython =
     py36: python3.6
 deps =
-	django-discover-runner
-	django111: django==1.11
-	django22: django==2.2
-	django30: django==3.0
-	coverage
-	ua_parser==0.7.1
-	mock==2.0.0
+    django-discover-runner
+    django111: django==1.11
+    django22: django==2.2
+    django30: django==3.0
+    coverage
+    ua_parser==0.7.1
+    mock==2.0.0
 
 [testenv:docs]
 basepython = python2.7
@@ -22,6 +22,7 @@ deps =
     Sphinx
     django==1.11
     ua_parser==0.7.1
+    coverage
 commands =
     make clean
     make html

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = {py36}-django{111,22,30}, docs, pep8
+envlist = {py38}-django{111,22,30}, docs, pep8
 
 [testenv]
 whitelist_externals = make
 commands = coverage run --source {envsitepackagesdir}/security --omit="*migrations/*" testing/manage.py test tests
 commands_post = coverage report
 basepython =
-    py36: python3.6
+    py38: python3.8
 deps =
 	django-discover-runner
 	django111: django==1.11
@@ -27,14 +27,15 @@ commands =
     make html
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.8
 deps=
     pep8-naming
     hacking
-    flake8==2.6.0
+    flake8
+    coverage
 commands=flake8 security testing
 
 [flake8]
-ignore=E131,H306,H301,H404,H405,H101,N802,N812
+ignore=E131,H306,H301,H404,H405,H101,N802,N812,W503
 max-complexity=10
 exclude=*migrations*

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = {py38}-django{111,22,30}, docs, pep8
+envlist = {py36}-django{111,22,30}, docs, pep8
 
 [testenv]
 whitelist_externals = make
 commands = coverage run --source {envsitepackagesdir}/security --omit="*migrations/*" testing/manage.py test tests
 commands_post = coverage report
 basepython =
-    py38: python3.8
+    py36: python3.6
 deps =
 	django-discover-runner
 	django111: django==1.11
@@ -27,7 +27,7 @@ commands =
     make html
 
 [testenv:pep8]
-basepython = python3.8
+basepython = python3.6
 deps=
     pep8-naming
     hacking


### PR DESCRIPTION
Also refactor **init** to reduce complexity and fix `tox.ini` and tox test failures

Fixes https://github.com/sdelements/django-security/issues/44
