### PR TITLE
Add support for Referrer-Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Middleware modules can be added to `MIDDLEWARE_CLASSES` list in settings file:
     ...
     'security.middleware.ContentNoSniff',
     'security.middleware.DoNotTrackMiddleware',
+    'security.middleware.ReferrerPolicyMiddleware',
     'security.middleware.XFrameOptionsMiddleware',
     'security.middleware.XssProtectMiddleware',
     )
@@ -91,6 +92,11 @@ or minimum configuration.
 <td><a href="http://django-security.readthedocs.org/en/latest/#security.middleware.P3PPolicyMiddleware">P3PPolicyMiddleware</a>
 <td>Adds the HTTP header attribute specifying compact P3P policy.
 <td>Required.
+
+<tr>
+<td><a href="http://django-security.readthedocs.org/en/latest/#security.middleware.ReferrerPolicyMiddleware">ReferrerPolicyMiddleware</a>
+<td>Specify when the browser will set a `Referer` header.
+<td>Optional.
 
 <tr>
 <td><a href="http://django-security.readthedocs.org/en/latest/#security.middleware.SessionExpiryPolicyMiddleware">SessionExpiryPolicyMiddleware</a>

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Middleware modules can be added to `MIDDLEWARE_CLASSES` list in settings file:
 
     MIDDLEWARE_CLASSES = (
     ...
-    'security.middleware.DoNotTrackMiddleware',
     'security.middleware.ContentNoSniff',
-    'security.middleware.XssProtectMiddleware',
+    'security.middleware.DoNotTrackMiddleware',
     'security.middleware.XFrameOptionsMiddleware',
+    'security.middleware.XssProtectMiddleware',
     )
 
 Unlike the modules listed above, some other modules **require**  configuration settings,

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -13,7 +13,7 @@ from django.test.signals import setting_changed
 from django.utils import timezone
 import django.views.static
 
-from ua_parser.user_agent_parser import ParseUserAgent
+from ua_parser import user_agent_parser
 
 from .password_expiry import password_is_expired
 
@@ -704,7 +704,7 @@ class ContentSecurityPolicyMiddleware(object):
         # choose headers based enforcement mode
         is_ie = False
         if 'HTTP_USER_AGENT' in request.META:
-            parsed_ua = ParseUserAgent(request.META['HTTP_USER_AGENT'])
+            parsed_ua = user_agent_parser.ParseUserAgent(request.META['HTTP_USER_AGENT'])
             is_ie = parsed_ua['family'] == 'IE'
 
         if self._enforce:

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -1056,6 +1056,6 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
         Add Referrer-Policy to the reponse header.
         """
         if self.option != 'off':
-            header = self.OPTIONS[self.option]
+            header = self.option
             response['Referrer-Policy'] = header
         return response

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -1004,7 +1004,7 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
     the `Referer` header. Use REFERRER_POLICY option in settings file
     with the following values:
 
-      ``no-referrer``   never set the `Referer` header (*default*)
+      ``no-referrer``
 
       ``no-referrer-when-downgrade``
 
@@ -1012,7 +1012,7 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
 
       ``origin-when-cross-origin``
 
-      ``same-origin``
+      ``same-origin`` (*default*)
 
       ``strict-origin``
 
@@ -1032,9 +1032,9 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
 
     OPTIONS = [ 'no-referrer', 'no-referrer-when-downgrade', 'origin',
     'origin-when-cross-origin', 'same-origin', 'strict-origin',
-    'strict-origin-when-cross-origin', 'unsafe-url' ]
+    'strict-origin-when-cross-origin', 'unsafe-url', 'off' ]
 
-    DEFAULT = 'no-referrer'
+    DEFAULT = 'same-origin'
 
     def load_setting(self, setting, value):
         if not value:
@@ -1055,6 +1055,7 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
         """
         Add Referrer-Policy to the reponse header.
         """
-        header = self.OPTIONS[self.option]
-        response['Referrer-Policy'] = header
+        if self.option != 'off':
+            header = self.OPTIONS[self.option]
+            response['Referrer-Policy'] = header
         return response

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -1032,7 +1032,7 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
 
     OPTIONS = [ 'no-referrer', 'no-referrer-when-downgrade', 'origin',
     'origin-when-cross-origin', 'same-origin', 'strict-origin',
-    'strict-origin-when-cross-origin', 'unsafe-url']
+    'strict-origin-when-cross-origin', 'unsafe-url' ]
 
     DEFAULT = 'no-referrer'
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,11 @@
 import os
 import sys
 import subprocess
-from distutils.core import setup, Command
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+from distutils.core import Command
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     readme = f.read()
@@ -39,5 +43,5 @@ setup(name="django-security",
 	  'Topic :: Security',
       ],
       requires=['django (>=1.4)', 'ua_parser (==0.7.1)'],
+      install_requires=['django>=1.4', 'ua_parser==0.7.1'],
       cmdclass={'test': Test})
-

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -59,6 +59,7 @@ MIDDLEWARE_CLASSES = (
     'security.middleware.MandatoryPasswordChangeMiddleware',
     'security.middleware.NoConfidentialCachingMiddleware',
     'security.auth_throttling.Middleware',
+    'security.middleware.ReferrerPolicyMiddleware',
 )
 ROOT_URLCONF = 'testing.urls'
 TEMPLATE_DIRS = (_os.path.join(_PROJECT_PATH, "templates"),)

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -979,3 +979,66 @@ class DoNotTrackTests(TestCase):
     def test_DNT_echo_default(self):
         self.dnt.process_response(self.request, self.response)
         self.assertNotIn('DNT', self.response)
+
+class ReferrerPolicyTests(TestCase):
+
+    def test_option_set(self):
+        """
+        Verify the HTTP Referrer-Policy Header is set.
+        """
+        response = self.client.get('/accounts/login/')
+        self.assertNotEqual(response['Referrer-Policy'], None)
+
+    def test_default_setting(self):
+        with self.settings(REFERRER_POLICY=None):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'no-referrer')
+
+    def test_no_referrer_setting(self):
+        with self.settings(REFERRER_POLICY='no-referrer'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'no-referrer')
+
+    def test_no_referrer_when_downgrade_setting(self):
+        with self.settings(REFERRER_POLICY='no-referrer-when-downgrade'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'no-referrer-when-downgrade')
+
+    def test_origin_setting(self):
+        with self.settings(REFERRER_POLICY='origin'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'origin')
+
+    def test_origin_when_cross_origin_setting(self):
+        with self.settings(REFERRER_POLICY='origin-when-cross-origin'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'origin-when-cross-origin')
+
+    def test_same_origin_setting(self):
+        with self.settings(REFERRER_POLICY='same-origin'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'same-origin')
+
+    def test_strict_origin_setting(self):
+        with self.settings(REFERRER_POLICY='strict-origin'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'strict-origin')
+
+    def test_strict_origin_when_cross_origin_setting(self):
+        with self.settings(REFERRER_POLICY='strict-origin-when-cross-origin'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'strict-origin-when-cross-origin')
+
+    def test_unsafe_url_setting(self):
+        with self.settings(REFERRER_POLICY='unsafe-url'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], 'unsafe-url')
+
+    def test_improper_configuration_raises(self):
+        referer_policy_middleware = ReferrerPolicyMiddleware()
+        self.assertRaises(
+            ImproperlyConfigured,
+            referer_policy_middleware.load_setting,
+            'REFERRER_POLICY',
+            'invalid',
+        )

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -22,7 +22,7 @@ from security.auth_throttling import (
 from security.middleware import (
     BaseMiddleware, ContentSecurityPolicyMiddleware, DoNotTrackMiddleware,
     SessionExpiryPolicyMiddleware, MandatoryPasswordChangeMiddleware,
-    XssProtectMiddleware, XFrameOptionsMiddleware,
+    XssProtectMiddleware, XFrameOptionsMiddleware, ReferrerPolicyMiddleware
 )
 from security.models import PasswordExpiry
 from security.password_expiry import never_expire_password
@@ -1037,7 +1037,7 @@ class ReferrerPolicyTests(TestCase):
     def test_off_setting(self):
         with self.settings(REFERRER_POLICY='off'):
             response = self.client.get('/accounts/login/')
-            self.assertEqual(response['Referrer-Policy'], None)
+            self.assertEqual('Referrer-Policy' in response, False)
 
     def test_improper_configuration_raises(self):
         referer_policy_middleware = ReferrerPolicyMiddleware()

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -992,7 +992,7 @@ class ReferrerPolicyTests(TestCase):
     def test_default_setting(self):
         with self.settings(REFERRER_POLICY=None):
             response = self.client.get('/accounts/login/')
-            self.assertEqual(response['Referrer-Policy'], 'no-referrer')
+            self.assertEqual(response['Referrer-Policy'], 'same-origin')
 
     def test_no_referrer_setting(self):
         with self.settings(REFERRER_POLICY='no-referrer'):
@@ -1033,6 +1033,11 @@ class ReferrerPolicyTests(TestCase):
         with self.settings(REFERRER_POLICY='unsafe-url'):
             response = self.client.get('/accounts/login/')
             self.assertEqual(response['Referrer-Policy'], 'unsafe-url')
+
+    def test_off_setting(self):
+        with self.settings(REFERRER_POLICY='off'):
+            response = self.client.get('/accounts/login/')
+            self.assertEqual(response['Referrer-Policy'], None)
 
     def test_improper_configuration_raises(self):
         referer_policy_middleware = ReferrerPolicyMiddleware()


### PR DESCRIPTION
Added support for the `Referrer-Policy` header with a good default value of `no-referrer`. New to django, so please let me know if I missed something :)

[Appcanary: About Referrer-Policy](https://blog.appcanary.com/2017/http-security-headers.html#referrer-policy)
[MDN Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)