### PR TITLE
change of content-type check in csp_report view

### DIFF
--- a/security/middleware.py
+++ b/security/middleware.py
@@ -8,7 +8,7 @@ from re import compile
 import django.conf
 from django.contrib.auth import logout
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse, resolve
+from django.urls import reverse, resolve
 from django.http import HttpResponseRedirect, HttpResponse
 from django.test.signals import setting_changed
 from django.utils import timezone

--- a/security/migrations/0001_initial.py
+++ b/security/migrations/0001_initial.py
@@ -34,7 +34,10 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('password_expiry_date', models.DateTimeField(help_text=b"The date and time when the user's password expires. If this is empty, the password never expires.", auto_now_add=True, null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    unique=True,
+                    on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'PasswordExpiries',

--- a/security/models.py
+++ b/security/models.py
@@ -24,7 +24,11 @@ class PasswordExpiry(models.Model):
         verbose_name_plural = "PasswordExpiries"
 
     # Not one-to-one because some users may never receive an expiry date.
-    user = models.ForeignKey(USER_MODEL, unique=True)
+    user = models.ForeignKey(
+        USER_MODEL,
+        unique=True,
+        on_delete=models.CASCADE
+    )
 
     password_expiry_date = models.DateTimeField(
         auto_now_add=True,

--- a/security/views.py
+++ b/security/views.py
@@ -59,7 +59,7 @@ def csp_report(request, csp_save=False, csp_log=True):
 
     if (
         'CONTENT_TYPE' not in request.META or
-        request.META['CONTENT_TYPE'] != 'application/json'
+        request.META['CONTENT_TYPE'] != 'application/csp-report'
     ):
         log.debug('Missing CSP report Content-Type %s', request.META)
         return HttpResponseForbidden()


### PR DESCRIPTION
currently the browsers `POST` the CSP report with `'application/csp-report'` content type and as such this change is needed for the `csp_report` view to work.