### PR TITLE
Allow newer versions of ua parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(name="django-security",
       ],
       install_requires=[
           'django>=1.8',
-          'ua_parser==0.7.1',
+          'ua_parser>=0.7.1',
       ],
       cmdclass={'test': Test})


### PR DESCRIPTION
We should be able to use newer versions of ua-parser