### PR TITLE
Add ClearSiteDataMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ or minimum configuration.
 </tr>
 
 <tr>
+<td><a href="http://django-security.readthedocs.org/en/latest/#security.middleware.ClearSiteDataMiddleware">ClearSiteDataMiddleware</a>
+<td>Send Clear-Site-Data header in HTTP response for any page that has been whitelisted. <em>Recommended,</em>.
+<td>Required.
+
+<tr>
 <td><a href="http://django-security.readthedocs.org/en/latest/#security.middleware.ContentNoSniff">ContentNoSniff</a>
 <td>Disable possibly insecure autodetection of MIME types in browsers. <em>Recommended.</em>
 <td>None.


### PR DESCRIPTION
Add a `ClearSiteDataMiddleware` and respective django settings.

`CLEAR_SITE_DATA_URL_WHITELIST` -  whitelist of URLs that Clear-Site-Data response header is applied to (eg. `/accounts/logout/`)
`CLEAR_SITE_DATA_DIRECTIVES` - what directives to apply (defaults to wildcard)

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data