### PR TITLE
Update urls path, previous is deprecated

### DIFF
--- a/security/middleware.py
+++ b/security/middleware.py
@@ -9,7 +9,7 @@ from re import compile
 import django.conf
 from django.contrib.auth import logout
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse, resolve
+from django.urls import reverse, resolve
 from django.http import HttpResponseRedirect, HttpResponse
 from django.test.signals import setting_changed
 from django.utils import timezone

--- a/testing/tests/tests.py
+++ b/testing/tests/tests.py
@@ -10,7 +10,7 @@ from django.contrib.auth import logout
 from django.contrib.auth.views import login
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms import ValidationError
 from django.http import HttpResponseForbidden, HttpRequest, HttpResponse
 from django.test import TestCase


### PR DESCRIPTION
This path was deprecated since version 1.10, but fully removed in 2.0

```python
from django.core.urlresolvers import reverse
```
to
```python
from django.urls import reverse
```