### PR TITLE
docs: Fix simple typo, proccessed -> processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See [documentation](http://django-security.readthedocs.org/en/latest/#security.v
 
 `require_ajax`
 
-A view decorator which ensures that the request being proccessed by view is an AJAX request. Example usage:
+A view decorator which ensures that the request being processed by view is an AJAX request. Example usage:
 
     @require_ajax
     def myview(request):

--- a/security/views.py
+++ b/security/views.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 def require_ajax(view):
     """
-    A view decorator which ensures that the request being proccessed
+    A view decorator which ensures that the request being processed
     by view is an AJAX request. We return a 403 error if the request
     is not an AJAX request.
     """


### PR DESCRIPTION
There is a small typo in README.md, security/views.py.

Should read `processed` rather than `proccessed`.

