### PR TITLE
Add support for new Content-Type

### DIFF
--- a/security/views.py
+++ b/security/views.py
@@ -58,7 +58,7 @@ def csp_report(request, csp_save=False, csp_log=True):
         return HttpResponseForbidden()
 
     content_type = request.META.get('CONTENT_TYPE', None)
-    if content_type != 'application/json':
+    if content_type != 'application/json' and content_type != 'application/csp-report':
         log.debug('Missing CSP report Content-Type %s', request.META)
         return HttpResponseForbidden()
 

--- a/security/views.py
+++ b/security/views.py
@@ -8,6 +8,8 @@ from django.views.decorators.csrf import csrf_exempt
 import logging
 log = logging.getLogger(__name__)
 
+ACCEPTABLE_CONTENT_TYPES = ['application/json', 'application/csp-report']
+
 
 def require_ajax(view):
     """
@@ -58,7 +60,7 @@ def csp_report(request, csp_save=False, csp_log=True):
         return HttpResponseForbidden()
 
     content_type = request.META.get('CONTENT_TYPE', None)
-    if content_type != 'application/json' and content_type != 'application/csp-report':
+    if content_type not in ACCEPTABLE_CONTENT_TYPES:
         log.debug('Missing CSP report Content-Type %s', request.META)
         return HttpResponseForbidden()
 


### PR DESCRIPTION
New Content-Type should be "application/csp-report"
https://w3c.github.io/webappsec-csp/

This should be merged (or fixed otherwise) ASAP because current content_type check breaks CSP reporting from new browsers.