### PR TITLE
Change versions to match

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,3 +1,3 @@
 django>=1.11
-ua_parser==0.7.1
-python-dateutil==2.8.0
+ua_parser>=0.7.1
+python-dateutil>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "django>=1.11",
         "ua_parser>=0.7.1",
-        "python-dateutil==2.8.1",
+        "python-dateutil>=2.8.1",
     ],
     cmdclass={"test": Test},
 )


### PR DESCRIPTION
Change versions in requirements to match those specified in setup.py.

Also, I’m seeing other libraries starting to require a minimum of `2.8.1` for `dateutils` and am starting to get dependency mismatches. I think it’s fairly safe to bump that version up.