### PR TITLE
docs: Fix a few typos

### DIFF
--- a/security/middleware.py
+++ b/security/middleware.py
@@ -252,7 +252,7 @@ class XssProtectMiddleware(BaseMiddleware):
 
     def process_response(self, request, response):
         """
-        Add X-XSS-Protection to the reponse header.
+        Add X-XSS-Protection to the response header.
         """
         header = self.OPTIONS[self.option]
         response['X-XSS-Protection'] = header
@@ -430,7 +430,7 @@ class NoConfidentialCachingMiddleware(BaseMiddleware):
     configured in ``NO_CONFIDENTIAL_CACHING`` dictionary in settings file with
     the following keys:
 
-        ``WHITELIST_ON``        all pages are confifendialt, except for pages
+        ``WHITELIST_ON``        all pages are confidential, except for pages
                                 explicitly whitelisted in ``WHITELIST_REGEXES``
 
         ``WHITELIST_REGEXES``   list of regular expressions defining pages
@@ -1362,7 +1362,7 @@ class ReferrerPolicyMiddleware(BaseMiddleware):
 
     def process_response(self, request, response):
         """
-        Add Referrer-Policy to the reponse header.
+        Add Referrer-Policy to the response header.
         """
         if self.option != 'off':
             header = self.option

--- a/security/models.py
+++ b/security/models.py
@@ -64,7 +64,7 @@ class CspReport(models.Model):
     were fired against the user and this raises a question how the malicious
     code appeared on your website.
 
-    CSP reports are available in Django admin view. To be logged into databse,
+    CSP reports are available in Django admin view. To be logged into database,
     CSP reports view needs to be configured properly. See csp_report_
     view for more information. Content Security Policy can be switched
     on for a web application using ContentSecurityPolicyMiddleware_ middleware.


### PR DESCRIPTION
There are small typos in:
- security/middleware.py
- security/models.py

Fixes:
- Should read `response` rather than `reponse`.
- Should read `database` rather than `databse`.
- Should read `confidential` rather than `confifendialt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md