### PR TITLE
Separate profiling middleware logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-security"
-version = "1.0.1"
+version = "1.0.2"
 homepage = "https://github.com/sdelements/django-security"
 description = "Models, views, middlewares and forms to facilitate security hardening of Django applications."
 authors = ["Security Compass <contact@securitycompass.com>"]

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -22,6 +22,8 @@ from django.utils.deprecation import MiddlewareMixin
 from ua_parser import user_agent_parser
 
 logger = logging.getLogger(__name__)
+profiling_logger = logger.getLogger("profiling")
+
 DJANGO_CLICKJACKING_MIDDLEWARE_URL = (
     "https://docs.djangoproject.com/en/4.2/ref/clickjacking/"
 )
@@ -1212,6 +1214,6 @@ class ProfilingMiddleware(BaseMiddleware):
             out.write(self.format_queries_and_time_for_logs(queries))
 
         out.write(self.request_separator)
-        logger.debug(out.getvalue())
+        profiling_logger.debug(out.getvalue())
 
         return response

--- a/security/middleware.py
+++ b/security/middleware.py
@@ -22,7 +22,7 @@ from django.utils.deprecation import MiddlewareMixin
 from ua_parser import user_agent_parser
 
 logger = logging.getLogger(__name__)
-profiling_logger = logger.getLogger("profiling")
+profiling_logger = logging.getLogger("profiling")
 
 DJANGO_CLICKJACKING_MIDDLEWARE_URL = (
     "https://docs.djangoproject.com/en/4.2/ref/clickjacking/"


### PR DESCRIPTION
* Profiling logs will write to 'profiling' logger instead of the standard 'security.middleware' logger

### Summary
- Write a quick summary of what this PR is for


##### Related Links
- Paste link to ticket or any other related sites here 

##### Ready for QA Checklist
- [ ] Code Review
- [ ] Dev QA
- [ ] Rebase and Squash
