### PR TITLE
Add support for using utf8 compatible keys

### DIFF
--- a/security/auth_throttling/__init__.py
+++ b/security/auth_throttling/__init__.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import time
+import urllib.parse
 from math import ceil
 
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -43,6 +44,13 @@ def delay_message(remainder):
         return _("%d seconds") % ceil(remainder)
 
 
+def _to_ascii_compatible(value: str):
+    if not value.isascii():
+        value = urllib.parse.quote(value)
+
+    return value
+
+
 def _key(counter_type, counter_name):
     """
     We store a hashed version of the key because what we generate can be
@@ -50,8 +58,8 @@ def _key(counter_type, counter_name):
     that memcache doesn't like.
     """
     key = "security.authentication_throttling.%s:%s" % (
-        counter_type,
-        counter_name,
+        _to_ascii_compatible(counter_type),
+        _to_ascii_compatible(counter_name),
     )
     return hashlib.sha256(key.encode("ascii")).hexdigest()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1074,13 +1074,17 @@ class ReferrerPolicyTests(TestCase):
 
 
 class UnicodeDataTests(TestCase):
-    def test_unicode_data_in_cache_key(self):
-        username = "ñoñó1234"
+    USERNAME = "ñoñó1234"
+    IP_ADDRESS = "127.0.0.1"
 
+    def test_unicode_data_in_cache_key(self):
+        self._execute_with_unicode_data(self.USERNAME, self.IP_ADDRESS)
+
+    def _execute_with_unicode_data(self, username, ip):
         try:
-            increment_counters(username=username, ip="127.0.0.1")
-            reset_counters(username=username, ip="127.0.0.1")
-            throttling_delay(username=username, ip="127.0.0.1")
+            increment_counters(username=username, ip=ip)
+            reset_counters(username=username, ip=ip)
+            throttling_delay(username=username, ip=ip)
             attempt_count(attempt_type="auth", id=username)
         except Exception:
-            self.fail("Unicodedata not allowed")
+            self.fail("Unicode data not allowed")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,7 +18,7 @@ from security.auth import min_length
 from security.auth_throttling import Middleware as AuthThrottlingMiddleware
 from security.auth_throttling import (attempt_count, default_delay_function,
                                       delay_message, increment_counters,
-                                      reset_counters)
+                                      reset_counters, throttling_delay)
 from security.middleware import (BaseMiddleware,
                                  ContentSecurityPolicyMiddleware,
                                  DoNotTrackMiddleware,
@@ -1071,3 +1071,16 @@ class ReferrerPolicyTests(TestCase):
             "REFERRER_POLICY",
             "invalid",
         )
+
+
+class UnicodeDataTests(TestCase):
+    def test_unicode_data_in_cache_key(self):
+        username = "ñoñó1234"
+
+        try:
+            increment_counters(username=username, ip="127.0.0.1")
+            reset_counters(username=username, ip="127.0.0.1")
+            throttling_delay(username=username, ip="127.0.0.1")
+            attempt_count(attempt_type="auth", id=username)
+        except Exception:
+            self.fail("Unicodedata not allowed")


### PR DESCRIPTION
- Change: counters passed to cache functions accept utf8 strings

### Summary
We want to implement utf8 compatible usernames, however, the cache keys only accept ascii keys. This allows UTF8 usernames and other keys to be used.


##### Related Links
- [TH-644](https://sdelements.atlassian.net/browse/TH-644)

##### Ready for QA Checklist
- [X] Code Review
- [X] Dev QA
- [ ] Rebase and Squash
