### PR TITLE
Making sure the cache key accepts any data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-security"
-version = "1.0.2"
+version = "1.0.3"
 homepage = "https://github.com/sdelements/django-security"
 description = "Models, views, middlewares and forms to facilitate security hardening of Django applications."
 authors = ["Security Compass <contact@securitycompass.com>"]

--- a/security/auth_throttling/__init__.py
+++ b/security/auth_throttling/__init__.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import time
+import typing
 import urllib.parse
 from math import ceil
 
@@ -44,8 +45,8 @@ def delay_message(remainder):
         return _("%d seconds") % ceil(remainder)
 
 
-def _to_ascii_compatible(value: str):
-    if not value.isascii():
+def _to_ascii_compatible(value: typing.Any):
+    if isinstance(value, str) and not value.isascii():
         value = urllib.parse.quote(value)
 
     return value

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1078,13 +1078,28 @@ class UnicodeDataTests(TestCase):
     IP_ADDRESS = "127.0.0.1"
 
     def test_unicode_data_in_cache_key(self):
-        self._execute_with_unicode_data(self.USERNAME, self.IP_ADDRESS)
+        self._execute_with_data(self.USERNAME, self.IP_ADDRESS)
 
-    def _execute_with_unicode_data(self, username, ip):
+    def test_types_in_cache_key(self):
+        """
+        We can send any kind of data for the downstream functions,
+        usually strings (maybe the username or email) and ints (maybe the userId)
+        """
+
+        self._execute_with_data(1, self.IP_ADDRESS)
+        self._execute_with_data(2.67, self.IP_ADDRESS)
+        self._execute_with_data(bool, self.IP_ADDRESS)
+        self._execute_with_data({"key": "value"}, self.IP_ADDRESS)
+        self._execute_with_data([1], self.IP_ADDRESS)
+        self._execute_with_data({1, 2}, self.IP_ADDRESS)
+        self._execute_with_data((1, 2), self.IP_ADDRESS)
+        self._execute_with_data("some_string", self.IP_ADDRESS)
+
+    def _execute_with_data(self, data, ip):
         try:
-            increment_counters(username=username, ip=ip)
-            reset_counters(username=username, ip=ip)
-            throttling_delay(username=username, ip=ip)
-            attempt_count(attempt_type="auth", id=username)
+            increment_counters(key=data, ip=ip)
+            reset_counters(key=data, ip=ip)
+            throttling_delay(username=data, ip=ip)
+            attempt_count(attempt_type="auth", id=data)
         except Exception:
-            self.fail("Unicode data not allowed")
+            self.fail("Unicode or incompatible data not allowed")


### PR DESCRIPTION
### Summary
This is a fix for bug introduced by [the previous PR](https://github.com/sdelements/django-security/pull/109), where if we pass an `int` to the `increment_counters` function, for example, it will raise a AttributeError, because we assumed the end user will only pass string data to it. 


##### Related Links
- [TH-644](https://sdelements.atlassian.net/browse/TH-644)

##### Ready for QA Checklist
- [x] Code Review
- [ ] Dev QA
- [x] Rebase and Squash
